### PR TITLE
Use Magma Blocks instead of Lava for world generation

### DIFF
--- a/src/main/java/cn/claycoffee/ClayTech/implementation/Planets/Mars.java
+++ b/src/main/java/cn/claycoffee/ClayTech/implementation/Planets/Mars.java
@@ -72,7 +72,7 @@ public class Mars extends ChunkGenerator {
 
                 if (finalHeight + 1 <= 57) {
                     for (int i = 57; i >= finalHeight + 1; i--) {
-                        chunkData.setBlock(x, i, z, Material.LAVA);
+                        chunkData.setBlock(x, i, z, Material.MAGMA_BLOCK);
                     }
                 } else if (finalHeight + 1 <= 60) {
                     for (int i = 60; i >= finalHeight + 1; i--) {

--- a/src/main/java/cn/claycoffee/ClayTech/implementation/Planets/Moon.java
+++ b/src/main/java/cn/claycoffee/ClayTech/implementation/Planets/Moon.java
@@ -46,7 +46,7 @@ public class Moon extends ChunkGenerator {
                 }
                 if (height <= 66) {
                     for (; height <= 66; height++) {
-                        chunkData.setBlock(x, height, z, Material.LAVA);
+                        chunkData.setBlock(x, height, z, Material.MAGMA_BLOCK);
                     }
                 } else {
                     chunkData.setBlock(x, height, z, Material.END_STONE);


### PR DESCRIPTION
Please use magma blocks instead of lava for world generation. you cause massive amounts of block lag everytime you generate due to lava being updated with flowing and still blocks.